### PR TITLE
Ap table update for L1 face attacks

### DIFF
--- a/L1-FACE_Toolbox_Inventory.adoc
+++ b/L1-FACE_Toolbox_Inventory.adoc
@@ -1,6 +1,6 @@
 = PAD-L1 Face Toolbox Inventory
 :showtitle:
-:revdate: 2025-12-05
+:revdate: 2026-03-31
 
 This document contains the inventory of tools and materials that are used in the context of the L1-Face toolbox.
 

--- a/L1-FACE_Toolbox_Overview.adoc
+++ b/L1-FACE_Toolbox_Overview.adoc
@@ -1,6 +1,6 @@
 = Face Toolbox Overview
 :showtitle:
-:revdate: 2025-12-23
+:revdate: 2026-03-31
 
 == Overview
 This toolbox contains a description of the process, tools, and materials needed to construct and use a selection of PAD-L1 face PAIs (see the Toolbox Overview for more information about PAD levels). As there is an almost unlimited number of possible PAIs that can be created at any PAD level, the set of PAIs here are considered a representative set of PAIs, not an exhaustive set.

--- a/L1-FACE_Toolbox_Overview.adoc
+++ b/L1-FACE_Toolbox_Overview.adoc
@@ -9,6 +9,8 @@ There are two categories of face artefacts that can be used for presentation att
 
 There are also two types of face biometric verification methods, 2D or 3D image-based methods. The 2D image-based method captures a two-dimensional face image with a sensor using visible light to recognize a person. The 3D image-based method creates three-dimensional model of the human face using a 3D scanner such as a depth camera.
 
+It is assumed that the 2D image-based method lacking any PAD functionality will fail this Level 1 Face PAD test.
+
 == Face Presentation Attacks
 === 2D Attacks
 There are many research papers that study face presentation attacks. In these papers, researchers typically create 2D face artefacts through the following process.

--- a/L1-FACE_Toolbox_References.adoc
+++ b/L1-FACE_Toolbox_References.adoc
@@ -32,7 +32,7 @@ https://doi.org/10.1109/BTAS.2013.6712688
 
 https://doi.org/10.1109/CVPRW.2016.193
 
-[9] [Bhattacharjee & Marcel, 2017] What you can’t see can help you – extended-range imaging for 3D-mask presentation attack detection
+[9] [Bhattacharjee & Marcel, 2017] What you can't see can help you – extended-range imaging for 3D-mask presentation attack detection
 
 https://doi.org/10.23919/BIOSIG.2017.8053524
 

--- a/L1-FACE_Toolbox_Verification_List.adoc
+++ b/L1-FACE_Toolbox_Verification_List.adoc
@@ -1,6 +1,6 @@
 = Face Toolbox Verification List
 :showtitle:
-:revdate: 2025-12-08
+:revdate: 2026-03-31
 
 This shows the list of tests and their applicability to different types of biometric sensors.
 

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -11,7 +11,7 @@ This attack has *4* species to be tested.
 The evaluator captures and prints target user's face on paper and presents it to the TOE. The presentation will be made using the photo flat and curved.
 
 == Input
-This attack assumes that target user’s facial images are available from the internet.
+This attack assumes that target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
 * FA1-T.2, Inkjet Printer or Service
@@ -91,7 +91,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 |Total
 
 |*Elapsed Time*
-|⇐ one day
+|<= one day
 |1
 |<= one hour
 |0

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -79,7 +79,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 
 *All Variations*     
 
-.Calculated Attack Potential Face attack 01-xx
+.Calculated Attack Potential Face attack FA1-01-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 |===

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -96,7 +96,6 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 .Calculated Attack Potential Face attack 01-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-01
 |===
 |Factor 
 |Identification Value

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -122,10 +122,10 @@ The attack potentials that are required to build the artefacts are summarized in
 
 |*Equipment*
 |Standard
-|1 
+|0 
 |Standard
-|2
-|3
+|0
+|0
 
 a|
 *Window of Opportunity*
@@ -154,7 +154,7 @@ a|
 |0
 |0
 
-6+^.^|Total Attack Potential = 8 < Basic Attack Potential
+6+^.^|Total Attack Potential = 5 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -90,7 +90,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential. 
 
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-01-01
+.Attack Potential L1-Face FA1-01
 |===
 |Factor 
 |Identification Value
@@ -100,9 +100,9 @@ The attack potentials that are required to build the artefacts are summarized in
 |Total
 
 |*Elapsed Time*
-|<= one week
+|⇐ one day
 |1
-|<= one day
+|<= one hour
 |0
 |1
 
@@ -112,12 +112,29 @@ The attack potentials that are required to build the artefacts are summarized in
 |Layman
 |0
 |0
- 
+
 |*Knowledge of TOE*    
 |Public
 |0 
-|N/A
-|
+|Public
+|0 
+|0
+
+|*Equipment*
+|Standard
+|1 
+|Standard
+|2
+|3
+
+a|
+*Window of Opportunity*
+
+*(Access to Biometric Characteristics)* 
+|Not needed
+|0
+|Without notice (Easy)
+|0
 |0
 
 a|
@@ -130,212 +147,14 @@ a|
 |4
 |4
 
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
+|*Degree of Scrutiny*
+|None
 |0 
-|Standard
+|None
 |0
 |0
 
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-01-02
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-01-03
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-01-04
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
+6+^.^|Total Attack Potential = 8 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -1,4 +1,5 @@
 = Attack L1-Face FA1-01-xx
+:xrefstyle: short
 
 == Attack type
 Printed photo attack

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -11,14 +11,15 @@ This attack has *4* species to be tested.
 The evaluator captures and prints target user's face on paper and presents it to the TOE. The presentation will be made using the photo flat and curved.
 
 == Input
-Target user's face
+This attack assumes that target user’s facial images are available from the internet.
 
-== Recipe
-The evaluator shall capture a face image and print it on paper. 
+== Common Attack Tools, Materials and Environment
+* FA1-T.2, Inkjet Printer or Service
+*	FA1-M.1, Matte or Service-specified
+*	FA1-E.1, Normal environment - 300 lux
 
-The evaluator shall refer to publicly available information to change default settings of the camera (e.g., picture size) and printer (e.g., output resolution) to create clearer face artefacts.
-
-The evaluator shall take at least three photos and select the best one to create each face artefact.
+== Common Recipe
+The evaluator shall capture a face image and print it on paper. The evaluator shall refer to publicly available information to change default settings of the camera (e.g., picture size) and printer (e.g., output resolution) to create clearer face artefacts. The evaluator shall take at least three photos and select the best one to create each face artefact and cut the face out of the photo to construct the PAI.
 
 == Variations
 The attack must be performed with each variation.
@@ -26,48 +27,32 @@ The attack must be performed with each variation.
 === Variation 1 (L1-Face FA1-01-01)
 *Normal Quality*
 
-==== Attack Tools/Media/Environment
-
+==== Attack Tools
 * FA1-T.1, Type 1 Mobile device camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 2 (L1-Face FA1-01-02)
 *High Quality*
 
-==== Attack Tools/Media/Environment
-
+==== Attack Tools
 * FA1-T.1, Type 2 Camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 3 (L1-Face FA1-01-03)
 *Normal Quality Curved*
 
 The artefact will be wrapped around the cylinder before presentation to the TOE.
 
-==== Attack Tools/Media/Environment
-
+==== Attack Tools/Media
 * FA1-T.1, Type 1 Mobile device camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
 * FA1-M.3, Head-sized cylinder
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 4 (L1-Face FA1-01-04)
 *High Quality Curved*
 
 The artefact will be wrapped around the cylinder before presentation to the TOE.
 
-==== Attack Tools/Media/Environment
-
+==== Attack Tools/Media
 * FA1-T.1, Type 2 Camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
 * FA1-M.3, Head-sized cylinder
-* FA1-E.1, Normal environment - 300 lux
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -87,8 +87,14 @@ The evaluator may, for example, change color effects of the camera to change the
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. In addition, the evaluator may deliberately warp a printed photo, trying to simulate facial motion (Warped photo attack) beyond the two options provided by flat and wrapped.  
 
 === Attack Potential Rating Suggestion
-The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential. 
+The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the printed photo described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+
+*All Variations*     
+
+.Calculated Attack Potential Face attack 01-xx
+[[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 .Attack Potential L1-Face FA1-01
 |===

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -60,7 +60,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-02-01
+.Attack Potential L1-Face FA1-02
 |===
 |Factor 
 |Identification Value
@@ -70,9 +70,9 @@ The attack potential that is required to build this artefact is summarized in th
 |Total
 
 |*Elapsed Time*
-|<= one week
+|⇐ one day
 |1
-|<= one day
+|<= one hour
 |0
 |1
 
@@ -82,12 +82,29 @@ The attack potential that is required to build this artefact is summarized in th
 |Layman
 |0
 |0
- 
+
 |*Knowledge of TOE*    
 |Public
 |0 
-|N/A
-|
+|Public
+|0 
+|0
+
+|*Equipment*
+|Standard
+|1 
+|Standard
+|2
+|3
+
+a|
+*Window of Opportunity*
+
+*(Access to Biometric Characteristics)* 
+|Not needed
+|0
+|Without notice (Easy)
+|0
 |0
 
 a|
@@ -100,87 +117,14 @@ a|
 |4
 |4
 
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
+|*Degree of Scrutiny*
+|None
 |0 
-|Standard
+|None
 |0
 |0
 
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-02-02
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
+6+^.^|Total Attack Potential = 8 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -1,4 +1,5 @@
 = Attack L1-Face FA1-02-xx
+:xrefstyle: short
 
 == Attack type
 Digital photo attack

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -61,7 +61,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 
 *All Variations*
 
-.Calculated Attack Potential Face attack 02-xx
+.Calculated Attack Potential Face attack FA1-02-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 |===

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -92,10 +92,10 @@ The attack potential that is required to build this artefact is summarized in th
 
 |*Equipment*
 |Standard
-|1 
+|0 
 |Standard
-|2
-|3
+|0
+|0
 
 a|
 *Window of Opportunity*
@@ -124,7 +124,7 @@ a|
 |0
 |0
 
-6+^.^|Total Attack Potential = 8 < Basic Attack Potential
+6+^.^|Total Attack Potential = 5 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -66,7 +66,6 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 .Calculated Attack Potential Face attack 02-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-02
 |===
 |Factor 
 |Identification Value

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -8,17 +8,16 @@ Digital photo attack
 This attack has *2* species to be tested.
 
 == Overview
-The evaluator captures and displays a target user's face on a mobile device screen and presents it to the TOE.
+The evaluator captures and displays a target user's face on a screen and presents it to the TOE.
 
 == Input
-Target user's face
+This attack assumes that target user’s facial images are available from the internet.
 
-== Recipe
-The evaluator shall capture a face image and display it on a screen. 
+== Common Attack Environment
+* FA1-E.1, Normal environment - 300 lux
 
-The evaluator shall refer to publicly available information to change default settings of the camera (e.g., picture size) to create clearer face artefacts.
-
-The evaluator shall take at least three photos and select the best one to create each face artefact.
+== Common Recipe
+The evaluator shall capture a face image and display it on a screen. The evaluator shall refer to publicly available information to change default settings of the camera (e.g., picture size) to create clearer face artefacts. The evaluator shall take at least three photos and select the best one to create each face artefact.
 
 == Variations
 The attack must be performed with each variation.
@@ -26,10 +25,9 @@ The attack must be performed with each variation.
 === Variation 1 (L1-Face FA1-02-01)
 *Normal Quality*
 
-==== Attack Tools/Media/Environment
+==== Attack Tools/Media
 * FA1-T.1, Type 1 Mobile device camera
 * FA1-M.2, Type 2 High resolution screen
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 2 (L1-Face FA1-02-02)
 *High Quality*
@@ -37,7 +35,6 @@ The attack must be performed with each variation.
 ==== Attack Tools/Media/Environment
 * FA1-T.1, Type 2 Camera
 * FA1-M.2, Type 2 High resolution screen
-* FA1-E.1, Normal environment - 300 lux
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -59,7 +59,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 === Attack Potential Rating Suggestion
 The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
-Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the digital photo described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the digital photo described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the digital photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
 
 *All Variations*
 

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -11,7 +11,7 @@ This attack has *2* species to be tested.
 The evaluator captures and displays a target user's face on a screen and presents it to the TOE.
 
 == Input
-This attack assumes that target user’s facial images are available from the internet.
+This attack assumes that target user's facial images are available from the internet.
 
 == Common Attack Environment
 * FA1-E.1, Normal environment - 300 lux
@@ -73,7 +73,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 |Total
 
 |*Elapsed Time*
-|⇐ one day
+|<= one day
 |1
 |<= one hour
 |0

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -57,8 +57,14 @@ The evaluator may, for example, change color effects of the camera to change the
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. 
 
 === Attack Potential Rating Suggestion
-The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
+The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the digital photo described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+
+*All Variations*
+
+.Calculated Attack Potential Face attack 02-xx
+[[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 .Attack Potential L1-Face FA1-02
 |===

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -58,8 +58,14 @@ The evaluator may, for example, change color effects of the camera to change the
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. 
 
 === Attack Potential Rating Suggestion
-The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
+The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the replay video  described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+
+*All Variations*
+
+.Calculated Attack Potential Face attack 03-xx
+[[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 .Attack Potential L1-Face FA1-03
 |===

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -11,34 +11,29 @@ This attack has *2* species to be tested.
 The evaluator records and replays a target user's face on a screen and presents it to the TOE.
 
 == Input
-Target user's face
+This attack assumes that a video of target user’s facial images are available from the internet.
 
-== Recipe
-The evaluator shall record a face image and replay it on a screen. 
+== Common Attack Tools, Materials and Environment
+* FA1-M.2, Type 2 High resolution screen
+*	FA1-E.1, Normal environment - 300 lux
 
-The evaluator shall refer to publicly available information to change default settings of the camera (e.g., frames per second) to create clearer face artefacts.
-
-The evaluator shall take at least three videos and select the best one to create each face artefact.
+== Common Recipe
+The evaluator shall record a face image and replay it on a screen. The evaluator shall refer to publicly available information to change default settings of the camera (e.g., frames per second) to create clearer face artefacts. The evaluator shall take at least three videos and select the best one to create each face artefact.
 
 == Variations
-
 The attack must be performed with each variation.
 
 === Variation 1 (L1-Face FA1-03-01)
 *Normal Quality*
 
-==== Attack Tools/Media/Environment
+==== Attack Tool
 * FA1-T.1, Type 1 Mobile device camera
-* FA1-M.2, Type 2 High resolution screen
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 2 (L1-Face FA1-03-02)
 *High Quality*
 
-==== Attack Tools/Media/Environment
+==== Attack Tool
 * FA1-T.1, Type 2 Camera
-* FA1-M.2, Type 2 High resolution screen
-* FA1-E.1, Normal environment - 300 lux
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -93,10 +93,10 @@ The attack potential that is required to build this artefact is summarized in th
 
 |*Equipment*
 |Standard
-|1 
+|0 
 |Standard
-|2
-|3
+|0
+|0
 
 a|
 *Window of Opportunity*
@@ -125,7 +125,7 @@ a|
 |0
 |0
 
-6+^.^|Total Attack Potential = 8 < Basic Attack Potential
+6+^.^|Total Attack Potential = 5 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -11,7 +11,7 @@ This attack has *2* species to be tested.
 The evaluator records and replays a target user's face on a screen and presents it to the TOE.
 
 == Input
-This attack assumes that a video of target user’s facial images are available from the internet.
+This attack assumes that a video of target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
 * FA1-M.2, Type 2 High resolution screen
@@ -72,7 +72,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 |Total
 
 |*Elapsed Time*
-|⇐ one day
+|<= one day
 |1
 |<= one hour
 |0

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -60,7 +60,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 
 *All Variations*
 
-.Calculated Attack Potential Face attack 03-xx
+.Calculated Attack Potential Face attack FA1-03-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 |===

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -61,7 +61,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-03-01
+.Attack Potential L1-Face FA1-03
 |===
 |Factor 
 |Identification Value
@@ -71,9 +71,9 @@ The attack potential that is required to build this artefact is summarized in th
 |Total
 
 |*Elapsed Time*
-|<= one week
+|⇐ one day
 |1
-|<= one day
+|<= one hour
 |0
 |1
 
@@ -83,12 +83,29 @@ The attack potential that is required to build this artefact is summarized in th
 |Layman
 |0
 |0
- 
+
 |*Knowledge of TOE*    
 |Public
 |0 
-|N/A
-|
+|Public
+|0 
+|0
+
+|*Equipment*
+|Standard
+|1 
+|Standard
+|2
+|3
+
+a|
+*Window of Opportunity*
+
+*(Access to Biometric Characteristics)* 
+|Not needed
+|0
+|Without notice (Easy)
+|0
 |0
 
 a|
@@ -101,87 +118,14 @@ a|
 |4
 |4
 
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
+|*Degree of Scrutiny*
+|None
 |0 
-|Standard
+|None
 |0
 |0
 
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-03-02
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
+6+^.^|Total Attack Potential = 8 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -1,4 +1,5 @@
 = Attack L1-Face FA1-03-xx
+:xrefstyle: short
 
 == Attack type
 Replay video attack

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -67,7 +67,6 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 .Calculated Attack Potential Face attack 03-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-03
 |===
 |Factor 
 |Identification Value

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -60,7 +60,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 === Attack Potential Rating Suggestion
 The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
-Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the replay video  described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the replay video  described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading a video of target facial image from the internet and attack the TOE using the video). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
 
 *All Variations*
 

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -61,7 +61,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 
 *All Variations*
 
-.Calculated Attack Potential Face attack 04-xx
+.Calculated Attack Potential Face attack FA1-04-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 |===

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -77,8 +77,14 @@ The evaluator may, for example, change color effects of the camera to change the
 As described in BIOSD, the evaluator may change the distance between the artefact and the TOE. The evaluator may also make cuts to the printed photo (Cut photo attack) to allow for better 3D fit or to provide an option for live feedback when presenting the photo, for example removing the eyes or mouth and aligning with the wearer, or making a slit for the nose. The evaluator shall create a mask which approximates the size of their own head so as to properly appear as a full face (e.g. not showing the edge of the mask and then a portion of the wearer's own face, which may require the evaluator to consider physical characteristics of the test subject when determining the best presentation). The evaluator should attempt to maintain similar physical conditions to the test subject capture (such as distance from the sensor) when presenting the attack. 
 
 === Attack Potential Rating Suggestion
-The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
+The attack potentials that are required to build the artefacts are summarized in the following table. See BIOSD Section 9 for more information about how to calculate attack potential.
 
+Attack Potential values are shown in <<calculatedtable>>. Attack Potential values for Identification account for the time, expertise, etc. required to make the printed face mask described in this attack. Attack potential for Exploitation corresponds to the effort to attack the TOE using the PAI in the actual environment (i.e., downloading the target facial image from the internet and attack the TOE using the printed photo). <<calculatedtable>> shows the final attack potential to rate the vulnerabilities and TOE resistance.
+
+*All Variations*
+
+.Calculated Attack Potential Face attack 04-xx
+[[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
 .Attack Potential L1-Face FA1-04
 |===

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -5,20 +5,21 @@
 Printed face mask attack
 
 === Total Number of Species
-This attack has *4* species to be tested.
+This attack has *2* species to be tested.
 
 == Overview
 The evaluator captures and prints a target user's face on paper, bends the paper to wear it as a face mask, and presents it to the TOE.
 
 == Input
-Target user's face
+This attack assumes that target user’s facial images are available from the internet.
 
-== Recipe
-The evaluator shall capture a face image and print it on paper. 
+== Common Attack Tools, Materials and Environment
+* FA1-T.2, Inkjet Printer or Service
+* FA1-M.1, Matte or Service-specified
+* FA1-E.1, Normal environment - 300 lux
 
-The evaluator shall refer to publicly available information to change default setting of the camera (e.g., picture size) and printer (e.g., output resolution) to create clearer face artefacts.
-
-The evaluator shall take at least three photos and select the best one to create each face artefact.
+== Common Recipe
+The evaluator shall capture a face image and print it on paper. The evaluator shall refer to publicly available information to change default setting of the camera (e.g., picture size) and printer (e.g., output resolution) to create clearer face artefacts. The evaluator shall take at least three photos and select the best one to create each face artefact and cut the face out of the photo to construct the PAI.
 
 == Variations
 The attack must be performed with each variation.
@@ -26,38 +27,14 @@ The attack must be performed with each variation.
 === Variation 1 (L1-Face FA1-04-01)
 *Normal Quality*
 
-==== Attack Tools/Media/Environment
+==== Attack Tool
 * FA1-T.1, Type 1 Mobile device camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.1, Normal environment - 300 lux
 
 === Variation 2 (L1-Face FA1-04-02)
 *High Quality*
 
 ==== Attack Tools/Media/Environment
 * FA1-T.1, Type 2 Camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.1, Normal environment - 300 lux
-
-=== Variation 3 (L1-Face FA1-04-03)
-*High Quality - Low Light*
-
-==== Attack Tools/Media/Environment
-* FA1-T.1, Type 2 Camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.2, Low light Environment - 150 lux
-
-=== Variation 4 (L1-Face FA1-04-04)
-*High Quality - Bright Light*
-
-==== Attack Tools/Media/Environment
-* FA1-T.1, Type 2 Camera
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
-* FA1-E.3, Bright Environment - >500 lux
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -112,10 +112,10 @@ The attack potential that is required to build this artefact is summarized in th
 
 |*Equipment*
 |Standard
-|1 
+|0 
 |Standard
-|2
-|3
+|0
+|0
 
 a|
 *Window of Opportunity*
@@ -144,7 +144,7 @@ a|
 |0
 |0
 
-6+^.^|Total Attack Potential = 8 < Basic Attack Potential
+6+^.^|Total Attack Potential = 5 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -86,7 +86,6 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 .Calculated Attack Potential Face attack 04-xx
 [[calculatedtable]]
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-04
 |===
 |Factor 
 |Identification Value

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -11,7 +11,7 @@ This attack has *2* species to be tested.
 The evaluator captures and prints a target user's face on paper, bends the paper to wear it as a face mask, and presents it to the TOE.
 
 == Input
-This attack assumes that target user’s facial images are available from the internet.
+This attack assumes that target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
 * FA1-T.2, Inkjet Printer or Service
@@ -73,7 +73,7 @@ Attack Potential values are shown in <<calculatedtable>>. Attack Potential value
 |Total
 
 |*Elapsed Time*
-|⇐ one day
+|<= one day
 |1
 |<= one hour
 |0

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -80,7 +80,7 @@ As described in BIOSD, the evaluator may change the distance between the artefac
 The attack potential that is required to build this artefact is summarized in the following table. See BIOSD Section 9 for more information about how to calculate the attack potential. 
 
 [cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-04-01
+.Attack Potential L1-Face FA1-04
 |===
 |Factor 
 |Identification Value
@@ -90,9 +90,9 @@ The attack potential that is required to build this artefact is summarized in th
 |Total
 
 |*Elapsed Time*
-|<= one week
+|⇐ one day
 |1
-|<= one day
+|<= one hour
 |0
 |1
 
@@ -102,12 +102,29 @@ The attack potential that is required to build this artefact is summarized in th
 |Layman
 |0
 |0
- 
+
 |*Knowledge of TOE*    
 |Public
 |0 
-|N/A
-|
+|Public
+|0 
+|0
+
+|*Equipment*
+|Standard
+|1 
+|Standard
+|2
+|3
+
+a|
+*Window of Opportunity*
+
+*(Access to Biometric Characteristics)* 
+|Not needed
+|0
+|Without notice (Easy)
+|0
 |0
 
 a|
@@ -120,212 +137,14 @@ a|
 |4
 |4
 
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
+|*Degree of Scrutiny*
+|None
 |0 
-|Standard
+|None
 |0
 |0
 
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-04-02
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-04-03
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
-
-|===
-
-
-[cols=".^2,.^2,^.^1,.^2,^.^1,^.^1",options="header",]
-.Attack Potential L1-Face FA1-04-04
-|===
-|Factor 
-|Identification Value
-|Score
-|Exploitation Value
-|Score
-|Total
-
-|*Elapsed Time*
-|<= one week
-|1
-|<= one day
-|0
-|1
-
-|*Expertise*
-|Layman
-|0
-|Layman
-|0
-|0
- 
-|*Knowledge of TOE*    
-|Public
-|0 
-|N/A
-|
-|0
-
-a|
-*Window of Opportunity*
-
-*(Access to TOE)* 
-|Easy
-|0
-|Moderate
-|4
-|4
-
-a|
-*Window of Opportunity*
-
-*(Access to Biometric Characteristics)* 
-|N/A
-|
-|Without notice
-|0
-|0
-
-|*Equipment*
-|Standard
-|0 
-|Standard
-|0
-|0
-
-6+^.^|Total Attack Potential = 5 < Basic Attack Potential
+6+^.^|Total Attack Potential = 8 < Basic Attack Potential
 
 |===
 

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -1,4 +1,5 @@
 = Attack L1-Face FA1-04-xx
+:xrefstyle: short
 
 == Attack type
 Printed face mask attack


### PR DESCRIPTION
This PR will update "Attack Potential Rating Suggestion" for each attack in L1 Face toolbox to align with the revised attack poetntial table by https://github.com/biometricITC/cPP-biometrics/pull/448
 and https://github.com/biometricITC/cPP-biometrics/pull/449.

In the previous version, an 'Attack Potential Rating Suggestion' was defined for each individual 'Variation.' However, these ratings should be defined at the attack level instead. Since variations—such as 'Normal' or 'High-Quality' printed photo attack —are components of a single attack type, 'Printed Photo Attack', the rating of this 'Printed Photo Attack' should encompass all related variations.