### PR TITLE
Update accuracy specifications for evaluator and lux meter

### DIFF
--- a/L1-FACE_Toolbox_Inventory.adoc
+++ b/L1-FACE_Toolbox_Inventory.adoc
@@ -17,11 +17,8 @@ Some examples:
 
 * The evaluator may connect a camera to a TV directly to replay a face image on a 4K screen
 * A camera video file could be imported to a PC from the camera and played directly from a 4K PC screen.
-+
+
 In such cases, the evaluator may use any PC and viewer software, however, the evaluator shall visually check the final image on the screen. If the evaluator sees any problem (e.g., choppy video playback because of an underpowered CPU), the evaluator shall replace the tools with an alternative that does not exhibit the problem. 
-* The evaluator needs a PC to install and run reconstruction software to generate 3D images.
-+
-In such cases, the evaluator may use any PC that meets the software's hardware requirements.
 
 == Tools Inventory
 .Tool Requirements

--- a/L1-FACE_Toolbox_Inventory.adoc
+++ b/L1-FACE_Toolbox_Inventory.adoc
@@ -100,23 +100,22 @@ For type 2 cameras with a lens, the following recommendations should be used:
 == Materials Inventory
 
 .Materials Requirements
-[cols=".^1,.^1,3,3",options="header"]
+[cols=".^1,.^1,3",options="header"]
 |===
 
 |ID
 |Category
-|Type 1
-|Type 2
+|Description
 
 |FA1-M.1 
 |Print paper            
-2+a|For inkjet printers Matte paper shall be used.
+|For inkjet printers Matte paper shall be used.
 
 Paper size shall be wide enough to include a test user's face in full scale
 
 |FA1-M.2 
 |Screen              
-2+a|High resolution screen
+a|High resolution screen
 
 * The evaluator shall use a UHD (4K) or higher resolution display (TV or computer monitor between 20"-30" diagonal size)
 ** Do not use Twisted Nematic (TN) or strobed backlight displays
@@ -125,7 +124,7 @@ Paper size shall be wide enough to include a test user's face in full scale
 
 |FA1-M.3
 |Cylinder
-2+a|Head-sized cylinder
+a|Head-sized cylinder
 
 A cylinder roughly 6" in diameter at least 1' in length.
 
@@ -143,7 +142,7 @@ Ideally the cylinder would be a material that can be used to tape photos to repe
 
 |ID
 |Category
-|Type 1
+|Description
 
 |FA1-E.1 
 |Normal Environment - 300 lux

--- a/L1-FACE_Toolbox_Inventory.adoc
+++ b/L1-FACE_Toolbox_Inventory.adoc
@@ -70,12 +70,20 @@ For all prints:
 * The evaluator shall crop the face from the printed photo, as some devices might detect the non-matching background.
 * The evaluator shall refer to publicly available information to select the best one (e.g., quality comparison report for professional print services). 
 * The evaluator shall follow recommendations from the printer guidance or professional print service (e.g., recommended image file size) to get the highest quality of photo print. 
+* Accuracy: within ±5%     
 
 |FA1-T.3
 |Standard Artefact
 2+|A standard artefact face mask that is not of a specific person (not a replication of a specific person). 
 
 The standard artefact is useful for expanding the range of faces that can be used for testing, not as attacks but for enrolment as the test user when possible.
+  
+|FA1-T.4 
+|Lux meter
+2+a|Lux meter that meets the following requirements: 
+
+* Minimum Range: 0 to 2,000 lux
+* Accuracy: within ±5%
 
 |===
 
@@ -143,22 +151,6 @@ a|* Lighting conditions that correspond to classical indoor lighting measured ar
 * Standard indoor background
 * No backlighting
 * No harsh or deep shadows should be visible on or across the face in the capture
-* No other faces (live or picture) present in the capture
-
-|FA1-E.2
-|Low light Environment - 150 lux
-a|* Lighting conditions that correspond to classical indoor lighting measured around 150 lux
-* Standard indoor background
-* No backlighting
-* Harsh or deep shadows should be visible on or across the face in the capture
-* No other faces (live or picture) present in the capture
-
-|FA1-E.3
-|Bright Environment - >500 lux
-a|* Lighting conditions that correspond to classical indoor lighting measured as greater than 500 lux
-* Standard indoor background
-* No backlighting
-* Harsh or deep shadows should be visible on or across the face in the capture
 * No other faces (live or picture) present in the capture
 
 |===

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -29,7 +29,7 @@ The attack must be performed with each variation.
 *Normal Quality*
 
 ==== Attack Tools
-* FA1-T.1, Type 1 Mobile device camera
+* FA1-T.1, Type 1 Camera
 
 === Variation 2 (L1-Face FA1-01-02)
 *High Quality*
@@ -43,8 +43,8 @@ The attack must be performed with each variation.
 The artefact will be wrapped around the cylinder before presentation to the TOE.
 
 ==== Attack Tools/Media
-* FA1-T.1, Type 1 Mobile device camera
-* FA1-M.3, Head-sized cylinder
+* FA1-T.1, Type 1 Camera
+* FA1-M.3, Cylinder
 
 === Variation 4 (L1-Face FA1-01-04)
 *High Quality Curved*
@@ -53,7 +53,7 @@ The artefact will be wrapped around the cylinder before presentation to the TOE.
 
 ==== Attack Tools/Media
 * FA1-T.1, Type 2 Camera
-* FA1-M.3, Head-sized cylinder
+* FA1-M.3, Cylinder
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-01-xx-Face_attack.adoc
+++ b/attacks/FA1-01-xx-Face_attack.adoc
@@ -14,8 +14,9 @@ The evaluator captures and prints target user's face on paper and presents it to
 This attack assumes that target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
-* FA1-T.2, Inkjet Printer or Service
-*	FA1-M.1, Matte or Service-specified
+* FA1-T.2, Photo Inkjet Printer or Service
+*	FA1-M.1, Print paper
+* FA1-T.4, Lux meter
 *	FA1-E.1, Normal environment - 300 lux
 
 == Common Recipe

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -15,6 +15,7 @@ This attack assumes that target user's facial images are available from the inte
 
 == Common Attack Environment
 * FA1-E.1, Normal environment - 300 lux
+* FA1-T.4, Lux meter
 
 == Common Recipe
 The evaluator shall capture a face image and display it on a screen. The evaluator shall refer to publicly available information to change default settings of the camera (e.g., picture size) to create clearer face artefacts. The evaluator shall take at least three photos and select the best one to create each face artefact.
@@ -26,7 +27,7 @@ The attack must be performed with each variation.
 *Normal Quality*
 
 ==== Attack Tools/Media
-* FA1-T.1, Type 1 Mobile device camera
+* FA1-T.1, Type 1 Camera
 * FA1-M.2, Screen
 
 === Variation 2 (L1-Face FA1-02-02)

--- a/attacks/FA1-02-xx-Face_attack.adoc
+++ b/attacks/FA1-02-xx-Face_attack.adoc
@@ -27,14 +27,14 @@ The attack must be performed with each variation.
 
 ==== Attack Tools/Media
 * FA1-T.1, Type 1 Mobile device camera
-* FA1-M.2, Type 2 High resolution screen
+* FA1-M.2, Screen
 
 === Variation 2 (L1-Face FA1-02-02)
 *High Quality*
 
 ==== Attack Tools/Media/Environment
 * FA1-T.1, Type 2 Camera
-* FA1-M.2, Type 2 High resolution screen
+* FA1-M.2, Screen
 
 == Prerequisite
 The evaluator shall enrol test users first as described in the Face Toolbox Overview. If the ST covers multiple configurations for face unlock, the same test shall be performed for all configurations.

--- a/attacks/FA1-03-xx-Face_attack.adoc
+++ b/attacks/FA1-03-xx-Face_attack.adoc
@@ -14,7 +14,8 @@ The evaluator records and replays a target user's face on a screen and presents 
 This attack assumes that a video of target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
-* FA1-M.2, Type 2 High resolution screen
+* FA1-M.2, Screen
+* FA1-T.4, Lux meter
 *	FA1-E.1, Normal environment - 300 lux
 
 == Common Recipe
@@ -27,7 +28,7 @@ The attack must be performed with each variation.
 *Normal Quality*
 
 ==== Attack Tool
-* FA1-T.1, Type 1 Mobile device camera
+* FA1-T.1, Type 1 Camera
 
 === Variation 2 (L1-Face FA1-03-02)
 *High Quality*

--- a/attacks/FA1-04-xx-Face_attack.adoc
+++ b/attacks/FA1-04-xx-Face_attack.adoc
@@ -14,8 +14,9 @@ The evaluator captures and prints a target user's face on paper, bends the paper
 This attack assumes that target user's facial images are available from the internet.
 
 == Common Attack Tools, Materials and Environment
-* FA1-T.2, Inkjet Printer or Service
-* FA1-M.1, Matte or Service-specified
+* FA1-T.2, Photo Inkjet Printer or Service
+* FA1-T.4, Lux meter
+* FA1-M.1, Print paper
 * FA1-E.1, Normal environment - 300 lux
 
 == Common Recipe
@@ -28,7 +29,7 @@ The attack must be performed with each variation.
 *Normal Quality*
 
 ==== Attack Tool
-* FA1-T.1, Type 1 Mobile device camera
+* FA1-T.1, Type 1 Camera
 
 === Variation 2 (L1-Face FA1-04-02)
 *High Quality*


### PR DESCRIPTION
Add new tool, lux meter, required to measure lightning condition (300 lux) and remove Low light and bright Environment from the inventory because they are not used in L1.